### PR TITLE
Fix kvm exit code

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -390,6 +390,8 @@ kvm()
             echo "Unknown command $1"
             return 1
     esac
+    
+    return 0
 }
 
 kvm list default >/dev/null && kvm use default >/dev/null || true


### PR DESCRIPTION
Added explicit return 0 to the end of the kvm command

fixes #27
