### PR TITLE
Updated execution profile

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -81,7 +81,7 @@ kvm unalias <alias>
 function Kvm-Global-Setup {
     If (Needs-Elevation)
     {
-        $arguments = "& '$scriptPath' setup $(Requested-Switches) -persistent"
+        $arguments = "-ExecutionPolicy unrestricted & '$scriptPath' setup $(Requested-Switches) -persistent"
         Start-Process "$psHome\powershell.exe" -Verb runAs -ArgumentList $arguments -Wait
         Write-Host "Setup complete"
         Kvm-Help


### PR DESCRIPTION
When running on a machine where Execution-Policy is default, the install script fails.
