### PR TITLE
Make kvm.ps1 work on Powershell < 4

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -22,6 +22,10 @@ $globalKrePath = $env:ProgramFiles + "\KRE"
 $globalKrePackages = $globalKrePath + "\packages"
 $feed = $env:KRE_NUGET_API_URL
 
+function String-IsEmptyOrWhitespace([string]$str) {
+     return [string]::IsNullOrEmpty($str) -or $str.Trim().length -eq 0 
+}
+
 if (!$feed)
 {
     $feed = "https://www.myget.org/F/aspnetvnext/api/v2";
@@ -275,7 +279,7 @@ param(
 
     Do-Kvm-Download $kreFullName $globalKrePackages
     Kvm-Use $versionOrAlias
-    if (![string]::IsNullOrEmpty($alias)) {
+    if (!$(String-IsEmptyOrWhitespace($alias))) {
         Kvm-Alias-Set $alias $versionOrAlias
     }
 }
@@ -317,7 +321,7 @@ param(
 
         $packageVersion = Package-Version $kreFullName
         Kvm-Use $packageVersion
-        if (![string]::IsNullOrEmpty($alias)) {
+        if (!$(String-IsEmptyOrWhitespace($alias))) {
             Kvm-Alias-Set $alias $packageVersion
         }
     }
@@ -330,7 +334,7 @@ param(
 
         Do-Kvm-Download $kreFullName $userKrePackages
         Kvm-Use $versionOrAlias
-        if (![string]::IsNullOrEmpty($alias)) {
+        if (!$(String-IsEmptyOrWhitespace($alias))) {
             Kvm-Alias-Set $alias $versionOrAlias
         }
     }


### PR DESCRIPTION
Changing IsNullOrWhiteSpace to IsNullOrEmpty makes kvm.ps1 work on Powershell versions before 4.
And it still works in Powershell 4.
