### PR TITLE
Updated kvm.sh to support renamed KRuntime mono45-x86 -> Mono

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -57,7 +57,7 @@ _kvm_package_name() {
 
 _kvm_package_runtime() {
     local kreFullName="$1"
-    echo "$kreFullName" | sed "s/KRE-\([^-]*\).*/\1/"
+    echo "$kreFullName" | sed "s/KRE-\([^.-]*\).*/\1/"
 }
 
 _kvm_download() {


### PR DESCRIPTION
Fixed returning of error codes from inner functions
