### PR TITLE
Remove Glob from find in kvm.sh

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -370,7 +370,7 @@ kvm()
             printf "$formatString" "------" "-------" "-------" "--------" "-----"
             
             local formattedHome=`(echo $KRE_USER_PACKAGES | sed s=$HOME=~=g)`
-            for f in $(find $KRE_USER_PACKAGES/* -name "$searchGlob" -type d -prune -exec basename {} \;); do
+            for f in $(find $KRE_USER_PACKAGES -name "$searchGlob" -type d -prune -exec basename {} \;); do
                 local active=""
                 [[ $PATH == *"$KRE_USER_PACKAGES/$f/bin"* ]] && local active="  *"
                 local pkgName=$(_kvm_package_runtime "$f")


### PR DESCRIPTION
Removed /\* Glob from find command in list to avoid conflict with some zsh variants

Fixes #45
