### PR TITLE
Split array declaration from initialization to avoid potential Z shell error

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -357,7 +357,10 @@ kvm()
             fi
             echo ""
             
-            local arr=()            
+            # Separate empty array declaration from initialization
+            # to avoid potential ZSH error: local:217: maximum nested function level reached
+            local arr
+            arr=()
             local i=0
             local format="%-20s %s\n"
             for _kvm_file in $(find "$KRE_USER_HOME/alias" -name *.alias); do


### PR DESCRIPTION
Error is: `local:217: maximum nested function level reached`. This error occurs when $SHELL is started.
Z shell version: `zsh 4.3.17 (x86_64-unknown-linux-gnu)`

Alternative would be to remove `local` keyword, but I assume the variable has no use outside the switch-case.
See http://zshwiki.org/home/scripting/array and http://stackoverflow.com/questions/14917501/local-arrays-in-zsh.
#### Screenshot:

![screenshot of zsh-prompt when loading](https://cloud.githubusercontent.com/assets/3382469/4382862/e498de38-4392-11e4-860d-012e85e45608.png)
