### PR TITLE
Fix kvm use <alias>

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -124,18 +124,12 @@ _kvm_requested_version_or_alias() {
         local pkgName=$(echo $kreFullName | sed "s/\([^.]*\).*/\1/")
         local pkgVersion=$(echo $kreFullName | sed "s/[^.]*.\(.*\)/\1/")
         local pkgPlatform=$(echo "$pkgName" | sed "s/KRE-\([^.-]*\).*/\1/")
-        local pkgArchitecture=$(echo "$pkgName" | sed "s/.*-.*-\([^-]*\).*/\1/")
     else
         local pkgVersion=$versionOrAlias
         local pkgPlatform="Mono"
-        local pkgArchitecture=
     fi
-    
-    if [[ -z $pkgArchitecture ]]; then
-        echo "KRE-$pkgPlatform.$pkgVersion"
-    else
-        echo "KRE-$pkgPlatform-$pkgArchitecture.$pkgVersion"
-    fi
+
+    echo "KRE-$pkgPlatform.$pkgVersion"
 }
 
 # This will be more relevant if we support global installs


### PR DESCRIPTION
Fixed issue where kvm use <alias> would still attempt to add the (deprecated) architecture to the path.
