### PR TITLE
Fix zsh issue where array-index starts at zero

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -355,7 +355,9 @@ kvm()
             # to avoid potential ZSH error: local:217: maximum nested function level reached
             local arr
             arr=()
-            local i=0
+
+            # Z shell array-index starts at one.
+            local i=1
             local format="%-20s %s\n"
             for _kvm_file in $(find "$KRE_USER_HOME/alias" -name *.alias); do
                 arr[$i]="$(basename $_kvm_file | sed 's/.alias//')/$(cat $_kvm_file)"


### PR DESCRIPTION
This is related to listing kre runtimes and associating with aliases.
Z shell arrays start at one versus Bash which starts at zero (ref. https://blogs.oracle.com/breakdown/entry/arrays_in_zsh).
New behavior is backwards-compatible with Bash, however (_at least from cursory local testing_).

**Note: this error only occurs if at-least one alias is defined (since the affecting loop is not executed when no aliases are defined – ref. [kvm.sh#L357-L360](https://github.com/aspnet/kvm/blob/d2713d5e0c298db5394ae6a9572d43d28125e532/src/kvm.sh#L357-L360).**
#### Current zsh error:

![image](https://cloud.githubusercontent.com/assets/3382469/4423083/ea3360e2-4591-11e4-8652-c12ae705bd7a.png)
