### PR TITLE
Use `-contains`

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -393,7 +393,7 @@ filter List-Parts {
   $delim=""
 
   foreach($alias in $aliases){
-    if($_.Name.Split('\', 2).Contains($alias.Name)){
+    if($_.Name.Split('\', 2) -contains $alias.Name){
         $fullAlias += $delim + $alias.Alias
         $delim = ", "
     }


### PR DESCRIPTION
PowerShell 2 errors with "Method invocation failed because [System.String[]] doesn't contain a method named 'IndexOf'.", see also https://github.com/aspnet/Home/pull/151
