### PR TITLE
Call k-crossgen.cmd directly instead via k.cmd with the crossgen option

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -373,7 +373,7 @@ param(
     }
     else {
       Console-Write "Compiling native images for $kreFullName to improve startup performance..."
-      Start-Process "K" -ArgumentList "crossgen" -Wait
+      Start-Process "k-crossgen" -Wait
       Console-Write "Finished native image compilation."
     }
   }


### PR DESCRIPTION
kvm install is not crossgening because k.cmd has been minimized
