### PR TITLE
KVM list on linux should include symlinks in search

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -375,7 +375,7 @@ kvm()
             printf "$formatString" "------" "-------" "-------" "--------" "-----"
 
             local formattedHome=`(echo $KRE_USER_PACKAGES | sed s=$HOME=~=g)`
-            for f in $(find $KRE_USER_PACKAGES -name "$searchGlob" -type d -prune -exec basename {} \;); do
+            for f in $(find $KRE_USER_PACKAGES -name "$searchGlob" \( -type d -or -type l \) -prune -exec basename {} \;); do
                 local active=""
                 [[ $PATH == *"$KRE_USER_PACKAGES/$f/bin"* ]] && local active="  *"
                 local pkgName=$(_kvm_package_runtime "$f")


### PR DESCRIPTION
KVM list did not include symlinks when displaying the installed versions. Because of that, the dev symlink would not be displayed.

@graemechristie, @davidfowl 
