### PR TITLE
Using a common env variable name to override the KRE feed url

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -31,7 +31,7 @@ $userKrePath = $env:USERPROFILE + "\.kre"
 $userKrePackages = $userKrePath + "\packages"
 $globalKrePath = $env:ProgramFiles + "\KRE"
 $globalKrePackages = $globalKrePath + "\packages"
-$feed = $env:KRE_NUGET_API_URL
+$feed = $env:KRE_FEED
 
 # In some environments, like Azure Websites, the Write-* cmdlets don't work
 $useHostOutputMethods = $true


### PR DESCRIPTION
Fixes bug: https://github.com/aspnet/kvm/issues/122
KRE_NUGET_API_URL -> KRE_FEED

@davidfowl 
