### PR TITLE
Remove global install and get the ps1 build working again

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -28,8 +28,8 @@ default DOTNETSDK_DEPLOY_BRANCH="${Environment.GetEnvironmentVariable("DOTNETSDK
         updateText = updateText.Replace("{{BUILD_NUMBER}}", Environment.GetEnvironmentVariable("BUILD_NUMBER"));
     }
 
--//#run-ps1-tests target='test' if='!IsLinux'
--//	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'
+#run-ps1-tests target='test' if='!IsLinux'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'
 
 -//#run-sh-tests target='test' if='IsLinux'
 -//    exec program='/bin/bash' commandline="${Path.Combine(TEST_DIR, "sh", "run-tests.sh")} ${IsTeamCity?"-t ":""}-v" workingdir="${Path.Combine(TEST_DIR, "sh")}"

--- a/test/apps/TestApp/Program.cs
+++ b/test/apps/TestApp/Program.cs
@@ -12,14 +12,17 @@ namespace HelloK {
 
         public int Main(string[] args) {
             var art =
-                "\x1b[33m   ___   _______  \x1b[34m  _  ____________" + Environment.NewLine +
-                "\x1b[33m  / _ | / __/ _ \\ \x1b[34m / |/ / __/_  __/" + Environment.NewLine +
-                "\x1b[33m / __ |_\\ \\/ ___/ \x1b[34m/    / _/  / /   " + Environment.NewLine +
-                "\x1b[33m/_/ |_/___/_/  \x1b[37m(_)\x1b[34m_/|_/___/ /_/    \x1b[39m";
+                "\x1b[34m" +
+                "      _  ____________" + Environment.NewLine +
+                "     / |/ / __/_  __/" + Environment.NewLine +
+                "    /    / _/  / /   " + Environment.NewLine +
+                "(_)/_/|_/___/ /_/    " +
+                "\x1b[39m";
 
             AnsiConsole.Output.WriteLine(art);
             AnsiConsole.Output.WriteLine("Runtime is sane!");
             AnsiConsole.Output.WriteLine("\x1b[30mRuntime Framework:    \x1b[39m " + _env.RuntimeFramework.ToString());
+            AnsiConsole.Output.WriteLine("\x1b[30mBitness:              \x1b[39m " + ((IntPtr.Size == 8) ? "64-bit" : "32-bit"));
 #if ASPNETCORE50
             AnsiConsole.Output.WriteLine("\x1b[30mRuntime:              \x1b[39m Microsoft CoreCLR");
 #else

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -25,13 +25,13 @@ function Remove-EnvVar($var) {
 function GetRuntimesOnPath {
     param($dotnetHome)
     if(!$dotnetHome) {
-        $dotnetHome = $env:USER_DOTNET_PATH
+        $dotnetHome = $env:DOTNET_USER_PATH
     }
 
     if($env:PATH) {
         $paths = $env:PATH.Split(";")
         if($paths) {
-            @($paths | Where { $_.StartsWith("$dotnetHome\packages") })
+            @($paths | Where { $_.StartsWith("$dotnetHome\runtimes") })
         }
     }
 }
@@ -44,17 +44,17 @@ function GetActiveRuntimePath {
 function GetActiveRuntimeName {
     param($dotnetHome)
     if(!$dotnetHome) {
-        $dotnetHome = $env:USER_DOTNET_PATH
+        $dotnetHome = $env:DOTNET_USER_PATH
     }
-    $activeKre = GetActiveRuntimePath $dotnetHome
-    if($activeKre) {
-        $activeKre.Replace("$dotnetHome\packages\", "").Replace("\bin", "")
+    $activeRuntime = GetActiveRuntimePath $dotnetHome
+    if($activeRuntime) {
+        $activeRuntime.Replace("$dotnetHome\runtimes\", "").Replace("\bin", "")
     }
 }
 
 function GetRuntimeName {
-    param($clr, $arch, $ver = $TestKreVersion)
-    "DotNet-$clr-$arch.$ver"
+    param($clr, $arch, $ver = $TestDotNetVersion)
+    "dotnet-$($clr.ToLowerInvariant())-win-$($arch.ToLowerInvariant()).$($ver.ToLowerInvariant())"
 }
 
 # Borrowed from kvm itself, but we can't really use that one so unfortunately we have to use copy-pasta :)

--- a/test/ps1/tests/DotNetSdk-Alias.Tests.ps1
+++ b/test/ps1/tests/DotNetSdk-Alias.Tests.ps1
@@ -1,5 +1,5 @@
 # Ensure a Runtime has been installed (if the other tests ran first, we're good)
-rundotnetsdk install $TestKreVersion -arch "x86" -r "CLR"
+rundotnetsdk install $TestDotNetVersion -arch "x86" -r "CLR"
 
 $notRealRuntimeVersion = "0.0.1-notarealruntime"
 
@@ -13,20 +13,20 @@ $bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
 
 Describe "dotnetsdk-ps1 alias" -Tag "dotnetsdk-alias" {
     Context "When defining an alias for a Runtime that exists" {
-        rundotnetsdk alias $testAlias $TestKreVersion -x86 -r CLR
+        rundotnetsdk alias $testAlias $TestDotNetVersion -x86 -r CLR
 
         It "writes the alias file" {
-            "$env:USER_DOTNET_PATH\alias\$testAlias.txt" | Should Exist
-            "$env:USER_DOTNET_PATH\alias\$testAlias.txt" | Should ContainExactly $kreName
+            "$env:DOTNET_USER_PATH\alias\$testAlias.txt" | Should Exist
+            "$env:DOTNET_USER_PATH\alias\$testAlias.txt" | Should ContainExactly $kreName
         }
     }
 
     Context "When defining an alias for a Runtime with no arch or clr parameters" {
-        rundotnetsdk alias $testDefaultAlias $TestKreVersion
+        rundotnetsdk alias $testDefaultAlias $TestDotNetVersion
 
         It "writes the x86/CLR variant to the alias file" {
-            "$env:USER_DOTNET_PATH\alias\$testDefaultAlias.txt" | Should Exist
-            "$env:USER_DOTNET_PATH\alias\$testDefaultAlias.txt" | Should ContainExactly $kreName   
+            "$env:DOTNET_USER_PATH\alias\$testDefaultAlias.txt" | Should Exist
+            "$env:DOTNET_USER_PATH\alias\$testDefaultAlias.txt" | Should ContainExactly $kreName   
         }
     }
 
@@ -34,8 +34,8 @@ Describe "dotnetsdk-ps1 alias" -Tag "dotnetsdk-alias" {
         rundotnetsdk alias $notRealAlias $notRealRuntimeVersion -x86 -r CLR
 
         It "writes the alias file" {
-            "$env:USER_DOTNET_PATH\alias\$notRealAlias.txt" | Should Exist
-            "$env:USER_DOTNET_PATH\alias\$notRealAlias.txt" | Should ContainExactly $notRealKreName   
+            "$env:DOTNET_USER_PATH\alias\$notRealAlias.txt" | Should Exist
+            "$env:DOTNET_USER_PATH\alias\$notRealAlias.txt" | Should ContainExactly $notRealKreName   
         }
     }
 
@@ -62,7 +62,7 @@ Describe "dotnetsdk-ps1 alias" -Tag "dotnetsdk-alias" {
         $allAliases = rundotnetsdk alias | Out-String
 
         It "lists all aliases in the alias files" {
-            dir "$env:USER_DOTNET_PATH\alias\*.txt" | ForEach-Object {
+            dir "$env:DOTNET_USER_PATH\alias\*.txt" | ForEach-Object {
                 $alias = [Regex]::Escape([IO.Path]::GetFileNameWithoutExtension($_.Name))
                 $val = [Regex]::Escape((Get-Content $_))
 
@@ -90,7 +90,7 @@ Describe "dotnetsdk-ps1 unalias" -Tag "dotnetsdk-alias" {
         rundotnetsdk unalias $testAlias
 
         It "removes the alias file" {
-            "$env:USER_DOTNET_PATH\alias\$testAlias.txt" | Should Not Exist
+            "$env:DOTNET_USER_PATH\alias\$testAlias.txt" | Should Not Exist
         }
     }
 }

--- a/test/ps1/tests/DotNetSdk-Install.Tests.ps1
+++ b/test/ps1/tests/DotNetSdk-Install.Tests.ps1
@@ -1,15 +1,6 @@
-$crossgenned=@("mscorlib")  # List of assemblies to check native images for on CoreCLR
-
-function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
-    $runtimeHome = $env:USER_DOTNET_PATH
-    $contextName = "for user"
+function DefineInstallTests($clr, $arch) {
+    $runtimeHome = $env:DOTNET_USER_PATH
     $alias = "install_test_$arch_$clr"
-
-    if($global) {
-        $contextName = "globally"
-        $alias = "global_$alias"
-        $runtimeHome = $env:GLOBAL_DOTNET_PATH
-    }
 
     if($clr -eq "CoreCLR") {
         $fxName = "Asp.NetCore,Version=v5.0"
@@ -20,39 +11,18 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
     $runtimeName = GetRuntimeName $clr $arch
     $runtimeRoot = "$runtimeHome\runtimes\$runtimeName"
 
-    $nativeText = ""
-    if($noNative) {
-        $nativeText = " (without building native images)"
-    }
-
-    Context "When installing $clr on $arch $contextName$nativeText" {
-        It "downloads and unpacks a KRE" {
-            if($global) {
-                rundotnetsdk install $TestDotNetVersion -arch $arch -r $clr -a $alias -global
-            } elseif($noNative) {
-                rundotnetsdk install $TestDotNetVersion -arch $arch -r $clr -a $alias -nonative    
-            } else {
-                rundotnetsdk install $TestDotNetVersion -arch $arch -r $clr -a $alias
-            }
+    Context "When installing $clr on $arch" {
+        It "downloads and unpacks a runtime" {
+            # Never crossgen in the automated tests since it takes a loooong time :(.
+            rundotnetsdk install $TestDotNetVersion -arch $arch -r $clr -a $alias -nonative
+            $dotnetsdkexit | Should Be 0
         }
 
-        It "installs the KRE into the user directory" {
+        It "installs the runtime into the user directory" {
             $runtimeRoot | Should Exist
         }
 
-        if($clr -eq "CoreCLR") {
-            if($noNative) {
-                It "did not crossgen native assemblies" {
-                    $crossgenned | ForEach-Object { "$runtimeRoot\bin\$_.ni.dll" } | Should Not Exist
-                }
-            } else {
-                It "crossgenned native assemblies" {
-                    $crossgenned | ForEach-Object { "$runtimeRoot\bin\$_.ni.dll" } | Should Exist
-                }
-            }
-        }
-
-        It "can restore packages for the HelloK sample" {
+        It "can restore packages for the TestApp sample" {
             pushd "$TestAppsDir\TestApp"
             try {
                 & "$runtimeRoot\bin\$PackageManagerName" restore
@@ -61,12 +31,13 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
             }
         }
 
-        It "can run the HelloK sample" {
+        It "can run the TestApp sample" {
             pushd "$TestAppsDir\TestApp"
             try {
                 $output = & "$runtimeRoot\bin\$RuntimeExecutableName" run
                 $LASTEXITCODE | Should Be 0
                 $fullOutput = [String]::Join("`r`n", $output)
+                $output | ForEach-Object { Write-Verbose "dotnet: $_" }
 
                 $fullOutput | Should Match "Runtime is sane!"
                 $fullOutput | Should Match "Runtime Framework:\s+$fxName"
@@ -76,8 +47,8 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
         }
 
         It "assigned the requested alias" {
-            "$env:USER_DOTNET_PATH\alias\$alias.txt" | Should Exist
-            "$env:USER_DOTNET_PATH\alias\$alias.txt" | Should ContainExactly $runtimeName
+            "$env:DOTNET_USER_PATH\alias\$alias.txt" | Should Exist
+            "$env:DOTNET_USER_PATH\alias\$alias.txt" | Should ContainExactly $runtimeName
         }
 
         It "uses the new Runtime" {
@@ -87,94 +58,81 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
 }
 
 Describe "dotnetsdk-ps1 install" -Tag "dotnetsdk-install" {
-    try {
-        DefineInstallTests "CLR" "x86"
-        DefineInstallTests "CLR" "amd64"
-        DefineInstallTests "CoreCLR" "x86" -noNative
-        DefineInstallTests "CoreCLR" "amd64"
-        DefineInstallTests "CLR" "x86" -global
+    DefineInstallTests "CLR" "x86"
+    DefineInstallTests "CLR" "x64"
+    DefineInstallTests "CoreCLR" "x86"
+    DefineInstallTests "CoreCLR" "x64"
 
-        Context "When installing a non-existant Runtime version" {
-            rundotnetsdk install "0.0.1-thisisnotarealruntime"
+    Context "When installing a non-existant Runtime version" {
+        rundotnetsdk install "0.0.1-thisisnotarealruntime"
 
-            It "returns a non-zero exit code" {
-                $dotnetsdkexit | Should Not Be 0
-            }
-
-            It "throws a 404 error" {
-                $dotnetsdkerr[0].Exception.Message | Should Be 'Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."'
-            }
+        It "returns a non-zero exit code" {
+            $dotnetsdkexit | Should Not Be 0
         }
 
-        Context "When no architecture is specified" {
-            rundotnetsdk install $TestDotNetVersion -r CLR
-            $runtimeName = GetRuntimeName -clr CLR -arch x86
-
-            It "uses x86" {
-                $dotnetsdkout[0] | Should Be "$runtimeName already installed."
-            }
-        }
-
-        Context "When no clr is specified" {
-            rundotnetsdk install $TestDotNetVersion -arch x86
-            $runtimeName = GetRuntimeName -clr CLR -arch x86
-
-            It "uses Desktop CLR" {
-                $dotnetsdkout[0] | Should Be "$runtimeName already installed."
-            }
-        }
-
-        Context "When neither architecture nor clr is specified" {
-            rundotnetsdk install $TestDotNetVersion
-            $runtimeName = GetRuntimeName -clr CLR -arch x86
-
-            It "uses x86/Desktop" {
-                $dotnetsdkout[0] | Should Be "$runtimeName already installed."
-            }
-        }
-
-        Context "When installing latest" {
-            $previous = @(dir "$env:USER_DOTNET_PATH\runtimes" | select -ExpandProperty Name)
-            It "downloads a runtime" {
-                rundotnetsdk install latest -arch x86 -r CLR
-            }
-            # TODO: Check that it actually installed the latest?
-        }
-
-        Context "When installing an already-installed runtime" {
-            # Clear active KRE
-            rundotnetsdk use none
-
-            $runtimeName = GetRuntimeName "CLR" "x86"
-            $runtimePath = "$env:USER_DOTNET_PATH\runtimes\$runtimeName"
-            It "ensures the runtime is installed" {
-                rundotnetsdk install $TestDotNetVersion -x86 -r "CLR"
-                $dotnetsdkout[0] | Should Match "$runtimeName already installed"
-                $runtimePath | Should Exist
-            }
-        }
-
-        Context "When installing a specific nupkg" {
-            $name = [IO.Path]::GetFileNameWithoutExtension($specificNupkgName)
-            $runtimeRoot = "$env:USER_DOTNET_PATH\runtimes\$name"
-
-            It "unpacks the runtime" {
-                rundotnetsdk install $specificNupkgPath
-            }
-
-            It "installs the runtime into the user directory" {
-                $runtimeRoot | Should Exist
-            }
-
-            It "did not assign an alias" {
-                dir "$env:USER_DOTNET_PATH\alias\*.txt" | ForEach-Object {
-                    $_ | Should Not Contain $name
-                }
-            }
+        It "throws a 404 error" {
+            $dotnetsdkerr[0].Exception.Message | Should Be 'Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."'
         }
     }
-    finally {
-        # Clean the global directory
-        del -rec -for $env:GLOBAL_DOTNET_PATH
+
+    Context "When no architecture is specified" {
+        rundotnetsdk install $TestDotNetVersion -r CLR
+        $runtimeName = GetRuntimeName -clr CLR -arch x86
+
+        It "uses x86" {
+            $dotnetsdkout[0] | Should Be "$runtimeName already installed."
+        }
+    }
+
+    Context "When no clr is specified" {
+        rundotnetsdk install $TestDotNetVersion -arch x86
+        $runtimeName = GetRuntimeName -clr CLR -arch x86
+
+        It "uses Desktop CLR" {
+            $dotnetsdkout[0] | Should Be "$runtimeName already installed."
+        }
+    }
+
+    Context "When neither architecture nor clr is specified" {
+        rundotnetsdk install $TestDotNetVersion
+        $runtimeName = GetRuntimeName -clr CLR -arch x86
+
+        It "uses x86/Desktop" {
+            $dotnetsdkout[0] | Should Be "$runtimeName already installed."
+        }
+    }
+
+    Context "When installing latest" {
+        $previous = @(dir "$env:DOTNET_USER_PATH\runtimes" | select -ExpandProperty Name)
+        It "downloads a runtime" {
+            rundotnetsdk install latest -arch x86 -r CLR
+        }
+        # TODO: Check that it actually installed the latest?
+    }
+
+    Context "When installing an already-installed runtime" {
+        # Clear active dotnet runtime
+        rundotnetsdk use none
+
+        $runtimeName = GetRuntimeName "CLR" "x86"
+        $runtimePath = "$env:DOTNET_USER_PATH\runtimes\$runtimeName"
+        It "ensures the runtime is installed" {
+            rundotnetsdk install $TestDotNetVersion -x86 -r "CLR"
+            $dotnetsdkout[0] | Should Match "$runtimeName already installed"
+            $runtimePath | Should Exist
+        }
+    }
+
+    Context "When installing a specific nupkg" {
+        $name = [IO.Path]::GetFileNameWithoutExtension($specificNupkgName)
+        $runtimeRoot = "$env:DOTNET_USER_PATH\runtimes\$name"
+
+        It "unpacks the runtime" {
+            rundotnetsdk install $specificNupkgPath
+        }
+
+        It "installs the runtime into the user directory" {
+            $runtimeRoot | Should Exist
+        }
     }
 }

--- a/test/ps1/tests/DotNetSdk-Use.Tests.ps1
+++ b/test/ps1/tests/DotNetSdk-Use.Tests.ps1
@@ -19,7 +19,7 @@ Describe "dotnetsdk-ps1 use" -Tag "dotnetsdk-use" {
         $runtimeName = GetRuntimeName -clr CLR -arch x86
 
         It "uses x86/CLR variant" {
-            GetActiveKreName | Should Be $runtimeName
+            GetActiveRuntimeName | Should Be $runtimeName
         }
 
         rundotnetsdk use none
@@ -29,49 +29,48 @@ Describe "dotnetsdk-ps1 use" -Tag "dotnetsdk-use" {
         rundotnetsdk use $TestDotNetVersion
         $runtimeName = GetRuntimeName -clr CLR -arch x86
 
+        # 'k.cmd' still exists, for now.
         It "puts K on the PATH" {
             $cmd = Get-Command k -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\k.cmd")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\k.cmd")
         }
 
         It "puts kpm on the PATH" {
             $cmd = Get-Command kpm -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\kpm.cmd")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\kpm.cmd")
         }
 
-        It "puts klr on the PATH" {
-            $cmd = Get-Command klr -ErrorAction SilentlyContinue
+        It "puts dotnet on the PATH" {
+            $cmd = Get-Command dotnet -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\klr.exe")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\dotnet.exe")
         }
 
         rundotnetsdk use none
     }
 
     Context "When use-ing an alias" {
-        # Sanity check assumptions
-        Get-Command k -ErrorAction SilentlyContinue | Should BeNullOrEmpty
-
         rundotnetsdk use $testAlias
 
+        # 'k.cmd' still exists, for now.
         It "puts K on the PATH" {
             $cmd = Get-Command k -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\k.cmd")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\k.cmd")
         }
 
         It "puts kpm on the PATH" {
             $cmd = Get-Command kpm -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\kpm.cmd")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\kpm.cmd")
         }
 
-        It "puts klr on the PATH" {
-            $cmd = Get-Command klr -ErrorAction SilentlyContinue
+        It "puts dotnet on the PATH" {
+            $cmd = Get-Command dotnet -ErrorAction SilentlyContinue
             $cmd | Should Not BeNullOrEmpty
-            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$runtimeName\bin\klr.exe")
+            $cmd.Definition | Should Be (Convert-Path "$env:DOTNET_USER_PATH\runtimes\$runtimeName\bin\dotnet.exe")
         }
     }
 
@@ -85,15 +84,15 @@ Describe "dotnetsdk-ps1 use" -Tag "dotnetsdk-use" {
         }
 
         It "removes K from the PATH" {
-            (Get-Command k -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
+            $cmd = (Get-Command k -ErrorAction SilentlyContinue)
         }
 
         It "removes kpm from the PATH" {
             (Get-Command kpm -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
         }
 
-        It "removes klr from the PATH" {
-            (Get-Command klr -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
+        It "removes dotnet from the PATH" {
+            (Get-Command dotnet -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
         }
     }
 
@@ -107,7 +106,7 @@ Describe "dotnetsdk-ps1 use" -Tag "dotnetsdk-use" {
     Context "When use-ing a non-existant alias" {
         It "should throw an error" {
             rundotnetsdk use "bogus_alias_that_does_not_exist"
-            $dotnetsdkerr[0].Exception.Message | Should Be "Cannot find DotNet-CLR-x86.bogus_alias_that_does_not_exist, do you need to run 'dotnetsdk install bogus_alias_that_does_not_exist'?"
+            $dotnetsdkerr[0].Exception.Message | Should Be "Cannot find dotnet-clr-win-x86.bogus_alias_that_does_not_exist, do you need to run 'dotnetsdk install bogus_alias_that_does_not_exist'?"
         }
     }
 }


### PR DESCRIPTION
This re-enables the PS1 tests. A separate PR will be coming to re-enable the SH tests later this afternoon and that PR will also enable automatic pushing to aspnet/Home.

Also, we removed global install from 'dotnetsdk'. There will be a proper Windows MSI to do global installs and the dotnetsdk global install risks colliding with that and causing confusion (if you install something one way, can you remove it the other way? etc.)