### PR TITLE
fix reference to $_KVM_RUNTIME_FOLDER_NAME

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -31,8 +31,8 @@ default KVM_DEPLOY_BRANCH="${Environment.GetEnvironmentVariable("KVM_DEPLOY_BRAN
 #run-ps1-tests target='test' if='!IsLinux'
 	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'
 
--//#run-sh-tests target='test' if='IsLinux'
--//    exec program='/bin/bash' commandline="${Path.Combine(TEST_DIR, "sh", "run-tests.sh")} ${IsTeamCity?"-t ":""}-v" workingdir="${Path.Combine(TEST_DIR, "sh")}"
+#run-sh-tests target='test' if='IsLinux'
+    exec program='/bin/bash' commandline="${Path.Combine(TEST_DIR, "sh", "run-tests.sh")} ${IsTeamCity?"-t ":""}-v" workingdir="${Path.Combine(TEST_DIR, "sh")}"
 
 #push-kvm target='deploy' if='DEPLOY_KVM == "1" && !String.IsNullOrEmpty(KVM_DEPLOY_REPO) && !String.IsNullOrEmpty(KVM_DEPLOY_BRANCH)'
 	push-kvm repo="${KVM_DEPLOY_REPO}" branch="${KVM_DEPLOY_BRANCH}" files="kvm.cmd;kvm.ps1;kvm.sh" baseMessage=":arrow_up: kvm.ps1, kvm.cmd, kvm.sh"

--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -9,7 +9,7 @@ _KVM_RUNTIME_SHORT_NAME="KRE"
 _KVM_RUNTIME_FOLDER_NAME=".k"
 _KVM_COMMAND_NAME="kvm"
 _KVM_VERSION_MANAGER_NAME="K Version Manager"
-_KVM_DEFAULT_FEED="https://www.myget.org/F/aspnetvnext/api/v2"
+_KVM_DEFAULT_FEED="https://www.myget.org/F/aspnetrelease/api/v2"
 _KVM_HOME_VAR_NAME="KRE_HOME"
 
 __kvm_has() {

--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -29,7 +29,7 @@ _KVM_USER_PACKAGES="$KVM_USER_HOME/runtimes"
 _KVM_ALIAS_DIR="$KVM_USER_HOME/alias"
 
 if [ -z "$KRE_FEED" ]; then
-    KRE_FEED="https://www.myget.org/F/aspnetvnext/api/v2"
+    KRE_FEED="$_KVM_DEFAULT_FEED"
 fi
 
 __kvm_find_latest() {

--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -22,7 +22,7 @@ if __kvm_has "unsetopt"; then
 fi
 
 if [ -z "$KVM_USER_HOME" ]; then
-    eval KVM_USER_HOME="~/$K_DIR_NAME"
+    eval KVM_USER_HOME="~/$_KVM_RUNTIME_FOLDER_NAME"
 fi
 
 _KVM_USER_PACKAGES="$KVM_USER_HOME/runtimes"

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -20,14 +20,14 @@ source $COMMON_HELPERS
 [ -z "$TEST_SHELLS" ]       && export TEST_SHELLS="bash zsh"
 [ -z "$TEST_DIR" ]          && export TEST_DIR="$SCRIPT_DIR/tests"
 [ -z "$CHESTER" ]           && export CHESTER="$SCRIPT_DIR/chester"
-[ -z "$KRE_FEED" ]          && export KRE_FEED="https://www.myget.org/F/aspnetvnext/api/v2" # doesn't really matter what the feed is, just that it is a feed
+[ -z "$KRE_FEED" ]          && export KRE_FEED="https://www.myget.org/F/aspnetrelease/api/v2" # doesn't really matter what the feed is, just that it is a feed
 [ -z "$TEST_APPS_DIR" ]     && export TEST_APPS_DIR="$REPO_ROOT/test/apps"
 
 export KRE_FEED
 
 # This is a KRE to use for testing various commands. It doesn't matter what version it is
-[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta3-10935"
-[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH="62951e3f3a3951e166cc28fcba00ff5716a3ddba"
+[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta3-11001"
+[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='a08277b15a967cb0a8239a1bac146e0c788ff78a'
 [ -z "$_NUPKG_URL" ]        && export _NUPKG_URL="$KRE_FEED/package/$_KVM_RUNTIME_PACKAGE_NAME-mono/$_TEST_VERSION"
 [ -z "$_NUPKG_NAME" ]       && export _NUPKG_NAME="$_KVM_RUNTIME_PACKAGE_NAME-mono.$_TEST_VERSION"
 [ -z "$_NUPKG_FILE" ]       && export _NUPKG_FILE="$TEST_WORK_DIR/${_NUPKG_NAME}.nupkg"


### PR DESCRIPTION
This is what I get for making a "quick change to a variable name" AFTER running all the tests and then not running the tests again... I'll verify this shortly on a Unix machine, I'm on a Windows box at the moment.