### PR TITLE
Add an option to parse global.json

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -1180,6 +1180,8 @@ function dnvm-upgrade {
     Make the installed runtime useable across all processes run by the current user
 .PARAMETER Unstable
     Upgrade from our unstable dev feed. This will give you the latest development version of the runtime.
+.PARAMETER File
+    A json file (global.json) that defines the version, architecture, and runtime to be installed.
 .DESCRIPTION
     A proxy can also be specified by using the 'http_proxy' environment variable
 #>
@@ -1223,9 +1225,26 @@ function dnvm-install {
         [switch]$Persistent,
 
         [Parameter(Mandatory=$false)]
-        [switch]$Unstable)
+        [switch]$Unstable,
+
+        [Parameter(Mandatory=$false)]
+        [string]$File)
 
     $selectedFeed = ""
+
+    if ($File) {
+        $json = (Get-Content $File -Raw) | ConvertFrom-Json
+        if ($json.sdk -and $json.sdk.version -and $json.sdk.architecture -and $json.sdk.runtime) {
+            $VersionNuPkgOrAlias = $json.sdk.version
+            $Architecture = $json.sdk.architecture
+            $Runtime = $json.sdk.runtime
+        } else {
+            _WriteOut "A version, architecture, and runtime must be provided in the file."
+            dnvm-help install
+            $Script:ExitCode = $ExitCodes.InvalidArguments
+            return
+        }
+    }
 
     if($Unstable) {
         $selectedFeed = $ActiveUnstableFeed


### PR DESCRIPTION
I don't know if you would be interested in something like this in dnvm.
I was thinking of having this option in dnvm to facilitate some deployment scenarios. Basically you end up with the user's repo which may contain a global.json that specifies the runtime version. Right now I have my own custom logic that parses that files and passes the right parameters to dnvm, but it would be nice if I can just pass the file as is and have dnvm do the right thing.

If this is something you would be interested in I can take a look at `dnvm.sh` as well
