### PR TITLE
dnvm returns non zero if no argument is passed

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -504,7 +504,7 @@ dnvm()
 
         printf "%b\n" "Use ${Yel}$_DNVM_COMMAND_NAME [help|-h|-help|--help] ${RCol} to display help text."
         echo ""
-        return
+        return 2
     fi
 
     case $1 in

--- a/test/sh/tests/help/Returns non zero exit code when no argument given.sh
+++ b/test/sh/tests/help/Returns non zero exit code when no argument given.sh
@@ -1,0 +1,6 @@
+source $COMMON_HELPERS
+source $_DNVM_PATH
+
+$_DNVM_COMMAND_NAME
+
+[ "$?" == "2" ] || die "expected exit code was not returned"

--- a/test/sh/tests/help/Returns zero exit code when help argument given.sh
+++ b/test/sh/tests/help/Returns zero exit code when help argument given.sh
@@ -1,0 +1,6 @@
+source $COMMON_HELPERS
+source $_DNVM_PATH
+
+$_DNVM_COMMAND_NAME help
+
+[ "$?" == "0" ] || die "expected exit code was not returned"


### PR DESCRIPTION
As per the discussion in aspnet/dnx#2920 @davidfowl said that `dnx` and `dnu` returns non zero exit code if no argument is provided because:
1. other well known programs do it
2. We had a bug once where the arguments changed and help was being output on the CI but nothing was failing

To be consistent, I think that also `dnvm` should have the same behaviour? I've only done Linux, but if You like the idea, I'm willing to also fix Windows.

//cc @moozzyk @BrennanConroy 
