### PR TITLE
Update dnvm.sh

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -351,8 +351,10 @@ __dnvm_requested_version_or_alias() {
         local pkgArchitecture="x64"
         local pkgSystem=$os
 
-        if [[ -z $runtime || "$runtime" == "mono" ]]; then
+        if [[ "$runtime" == "mono" ]]; then
             echo "$_DNVM_RUNTIME_PACKAGE_NAME-mono.$pkgVersion"
+		elif [[ -z $runtime ]]; then
+			echo "$pkgVersion"
         else
             if [ "$arch" != "" ]; then
                 local pkgArchitecture="$arch"


### PR DESCRIPTION
This should give a more accurate name, particularly when a bad name is specified. I believe this will be less confusing.

Previously:

```
dnvm alias default badname
dnx-mono.badname is not an installed DNX version
```

Now:

```
dnvm alias default badname
badname is not an installed DNX version
```

This is more obvious if you did:

```
dnvm alias default 1.0.0-rc1-update1
dnx-mono.1.0.0-rc1-update1 is not an installed DNX version
```

This confused me into thinking it was looking for a mono version.
