### PR TITLE
Using find -o instead of -or

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -948,7 +948,7 @@ dnvm()
             for location in `echo $DNX_HOME | tr ":" "\n"`; do
                 location+="/runtimes"
                 if [ -d "$location" ]; then
-                    local oruntimes="$(find $location -name "$searchGlob" \( -type d -or -type l \) -prune -exec basename {} \;)"
+                    local oruntimes="$(find $location -name "$searchGlob" \( -type d -o -type l \) -prune -exec basename {} \;)"
                     for v in `echo $oruntimes | tr "\n" " "`; do
                         runtimes+="$v:$location"$'\n'
                     done


### PR DESCRIPTION
BusyBox `find` didn't recognize -or but -o

According to the find manual -or is not POSIX compliant.

Before this change commands such as `dnvm list` failed.
